### PR TITLE
Support unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ Next add the validation-error-field component to the template
 {{/each}}
 ```
 
+The array based validation also supports the ability to re-compute each field when any model in the array has the specific field updated. To opt-in pass the array property like you see in the example below.
+
+```js
+{{#each model as |person index|}}
+    {{input value=person.name placeholder="name"}}
+    {{#validation-error-field array=model submitted=submitted field="name" model=person index=index validation="name"}}invalid name{{/validation-error-field}}
+{{/each}}
+```
+
 ## Running the unit tests
 
     npm install

--- a/addon/components/validation-error-field.js
+++ b/addon/components/validation-error-field.js
@@ -3,13 +3,16 @@ import Ember from "ember";
 var ValidationErrorField = Ember.Component.extend({
     tagName: "span",
     classNameBindings: ["visible"],
-    attributeBindings: ["className", "model", "field", "validation", "submitted", "delayed", "index"],
+    attributeBindings: ["array", "className", "model", "field", "validation", "submitted", "delayed", "index"],
     initialize: Ember.on("init", function() {
         var field = this.get("field");
         Ember.Binding.from("model." + field).to("fieldName").connect(this);
         Ember.Binding.from("model." + field + "IsPrimed").to("isPrimed").connect(this);
 
         var computedKeys = ["validation", "isPrimed", "submitted", "fieldName"];
+        if(this.get("array")) {
+            computedKeys.push("array.@each." + field);
+        }
 
         Ember.defineProperty(this, "visible", Ember.computed(computedKeys.join(","), function() {
             var index = this.get("index");

--- a/addon/components/validation-error-field.js
+++ b/addon/components/validation-error-field.js
@@ -4,25 +4,28 @@ var ValidationErrorField = Ember.Component.extend({
     tagName: "span",
     classNameBindings: ["visible"],
     attributeBindings: ["className", "model", "field", "validation", "submitted", "delayed", "index"],
-    visible: Ember.computed("validation", "isPrimed", "submitted", "fieldName", function() {
-        var index = this.get("index");
-        var isPrimed = this.get("isPrimed");
-        var delayed = this.get("delayed");
-        var submitted = this.get("submitted");
-        var className = this.get("className");
-        var validator = this.get("validation");
-        var fieldValidation = this.get("targetObject." + validator + index + "Validation");
-        var validation = index >= 0 ? fieldValidation : validator;
-        var condition = delayed === true ? !validation && submitted : !validation && (isPrimed || submitted);
-        if(condition) {
-            return className;
-        }
-        return className ? "hidden " + className : "hidden";
-    }),
     initialize: Ember.on("init", function() {
         var field = this.get("field");
         Ember.Binding.from("model." + field).to("fieldName").connect(this);
         Ember.Binding.from("model." + field + "IsPrimed").to("isPrimed").connect(this);
+
+        var computedKeys = ["validation", "isPrimed", "submitted", "fieldName"];
+
+        Ember.defineProperty(this, "visible", Ember.computed(computedKeys.join(","), function() {
+            var index = this.get("index");
+            var isPrimed = this.get("isPrimed");
+            var delayed = this.get("delayed");
+            var submitted = this.get("submitted");
+            var className = this.get("className");
+            var validator = this.get("validation");
+            var fieldValidation = this.get("targetObject." + validator + index + "Validation");
+            var validation = index >= 0 ? fieldValidation : validator;
+            var condition = delayed === true ? !validation && submitted : !validation && (isPrimed || submitted);
+            if(condition) {
+                return className;
+            }
+            return className ? "hidden " + className : "hidden";
+        }));
     })
 });
 

--- a/tests/acceptance/many-people-unique-name-test.js
+++ b/tests/acceptance/many-people-unique-name-test.js
@@ -1,0 +1,53 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { test, module } from 'qunit';
+
+var application;
+
+const SAVE_BUTTON = 'button.save';
+const FIRST_NAME_INPUT_ERROR = '.name-parent-div:eq(0) span.name-input-error';
+const FIRST_NAME_INPUT = '.name-parent-div:eq(0) input';
+
+const SECOND_NAME_INPUT_ERROR = '.name-parent-div:eq(1) span.name-input-error';
+const SECOND_NAME_INPUT = '.name-parent-div:eq(1) input';
+
+const THIRD_NAME_INPUT_ERROR = '.name-parent-div:eq(2) span.name-input-error';
+const THIRD_NAME_INPUT = '.name-parent-div:eq(2) input';
+
+module('Acceptance: Multiple People Unique Name', {
+    setup: function () {
+        application = startApp();
+    },
+    teardown: function () {
+        Ember.run(application, 'destroy');
+    }
+});
+
+test('all people must have a unique name', function (assert) {
+    visit('/many-single-property');
+    andThen(function () {
+        assert.equal(find(FIRST_NAME_INPUT_ERROR).hasClass('hidden'), true);
+        assert.equal(find(SECOND_NAME_INPUT_ERROR).hasClass('hidden'), true);
+        assert.equal(find(THIRD_NAME_INPUT_ERROR).hasClass('hidden'), true);
+    });
+    fillIn(FIRST_NAME_INPUT, 'Steve');
+    fillIn(SECOND_NAME_INPUT, 'Steve');
+    fillIn(THIRD_NAME_INPUT, 'Sam');
+    andThen(function () {
+        assert.equal(find(FIRST_NAME_INPUT_ERROR).hasClass('hidden'), true);
+        assert.equal(find(SECOND_NAME_INPUT_ERROR).hasClass('hidden'), true);
+        assert.equal(find(THIRD_NAME_INPUT_ERROR).hasClass('hidden'), true);
+    });
+    click(SAVE_BUTTON);
+    andThen(function () {
+        assert.equal(find(FIRST_NAME_INPUT_ERROR).hasClass('hidden'), false);
+        assert.equal(find(SECOND_NAME_INPUT_ERROR).hasClass('hidden'), false);
+        assert.equal(find(THIRD_NAME_INPUT_ERROR).hasClass('hidden'), true);
+    });
+    fillIn(FIRST_NAME_INPUT, "Bob");
+    andThen(function () {
+        assert.equal(find(FIRST_NAME_INPUT_ERROR).hasClass('hidden'), true);
+        assert.equal(find(THIRD_NAME_INPUT_ERROR).hasClass('hidden'), true);
+        assert.equal(find(SECOND_NAME_INPUT_ERROR).hasClass('hidden'), true);
+    });
+});

--- a/tests/acceptance/many-people-unique-name-test.js
+++ b/tests/acceptance/many-people-unique-name-test.js
@@ -44,10 +44,14 @@ test('all people must have a unique name', function (assert) {
         assert.equal(find(SECOND_NAME_INPUT_ERROR).hasClass('hidden'), false);
         assert.equal(find(THIRD_NAME_INPUT_ERROR).hasClass('hidden'), true);
     });
-    fillIn(FIRST_NAME_INPUT, "Bob");
+    fillIn(FIRST_NAME_INPUT, 'Bob');
     andThen(function () {
         assert.equal(find(FIRST_NAME_INPUT_ERROR).hasClass('hidden'), true);
         assert.equal(find(THIRD_NAME_INPUT_ERROR).hasClass('hidden'), true);
         assert.equal(find(SECOND_NAME_INPUT_ERROR).hasClass('hidden'), true);
+    });
+    click(SAVE_BUTTON);
+    andThen(function() {
+        assert.equal(currentURL(), '/success');
     });
 });

--- a/tests/acceptance/multi-starting-empty-validation-test.js
+++ b/tests/acceptance/multi-starting-empty-validation-test.js
@@ -29,7 +29,7 @@ module('Acceptance: Multi Starting Empty Validation', {
   }
 });
 
-test('clicking save will not transition to success when only the last field is valid', function(assert) {
+test('unique name validation will fire for newly added models and when a model is removed', function(assert) {
   visit('/multi-starting-empty');
   click(ADD_BUTTON);
   click(ADD_BUTTON);

--- a/tests/acceptance/multi-starting-empty-validation-test.js
+++ b/tests/acceptance/multi-starting-empty-validation-test.js
@@ -29,7 +29,7 @@ module('Acceptance: Multi Starting Empty Validation', {
   }
 });
 
-test('toran clicking save will not transition to success when only the last field is valid', function(assert) {
+test('clicking save will not transition to success when only the last field is valid', function(assert) {
   visit('/multi-starting-empty');
   click(ADD_BUTTON);
   click(ADD_BUTTON);

--- a/tests/acceptance/multi-starting-empty-validation-test.js
+++ b/tests/acceptance/multi-starting-empty-validation-test.js
@@ -1,0 +1,77 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { test, module } from 'qunit';
+
+var application;
+
+const ADD_BUTTON = 'button.add';
+const SAVE_BUTTON = 'button.save';
+const REMOVE_LAST_BUTTON = 'button.remove:eq(3)';
+
+const FIRST_NAME_ERROR_FIELD = '.name-parent-div:eq(0) span';
+const FIRST_NAME_INPUT = '.name-parent-div:eq(0) input';
+
+const SECOND_NAME_ERROR_FIELD = '.name-parent-div:eq(1) span';
+const SECOND_NAME_INPUT = '.name-parent-div:eq(1) input';
+
+const THIRD_NAME_ERROR_FIELD = '.name-parent-div:eq(2) span';
+const THIRD_NAME_INPUT = '.name-parent-div:eq(2) input';
+
+const FOURTH_NAME_ERROR_FIELD = '.name-parent-div:eq(3) span';
+const FOURTH_NAME_INPUT = '.name-parent-div:eq(3) input';
+
+module('Acceptance: Multi Starting Empty Validation', {
+  setup: function() {
+    application = startApp();
+  },
+  teardown: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('toran clicking save will not transition to success when only the last field is valid', function(assert) {
+  visit('/multi-starting-empty');
+  click(ADD_BUTTON);
+  click(ADD_BUTTON);
+  fillIn(FIRST_NAME_INPUT, 'toran');
+  fillIn(SECOND_NAME_INPUT, 'brandon');
+  andThen(function() {
+    assert.equal(find(FIRST_NAME_ERROR_FIELD).hasClass('hidden'), true);
+    assert.equal(find(SECOND_NAME_ERROR_FIELD).hasClass('hidden'), true);
+  });
+  click(ADD_BUTTON);
+  andThen(function() {
+    assert.equal(find(FIRST_NAME_ERROR_FIELD).hasClass('hidden'), true);
+    assert.equal(find(SECOND_NAME_ERROR_FIELD).hasClass('hidden'), true);
+    assert.equal(find(THIRD_NAME_ERROR_FIELD).hasClass('hidden'), true);
+  });
+  fillIn(THIRD_NAME_INPUT, 'toran');
+  andThen(function() {
+    assert.equal(find(FIRST_NAME_ERROR_FIELD).hasClass('hidden'), false);
+    assert.equal(find(SECOND_NAME_ERROR_FIELD).hasClass('hidden'), true);
+    assert.equal(find(THIRD_NAME_ERROR_FIELD).hasClass('hidden'), false);
+  });
+  fillIn(FIRST_NAME_INPUT, 'toranz');
+  andThen(function() {
+    assert.equal(find(FIRST_NAME_ERROR_FIELD).hasClass('hidden'), true);
+    assert.equal(find(SECOND_NAME_ERROR_FIELD).hasClass('hidden'), true);
+    assert.equal(find(THIRD_NAME_ERROR_FIELD).hasClass('hidden'), true);
+  });
+  click(ADD_BUTTON);
+  fillIn(FOURTH_NAME_INPUT, 'brandon');
+  andThen(function() {
+    assert.equal(find(FIRST_NAME_ERROR_FIELD).hasClass('hidden'), true);
+    assert.equal(find(SECOND_NAME_ERROR_FIELD).hasClass('hidden'), false);
+    assert.equal(find(THIRD_NAME_ERROR_FIELD).hasClass('hidden'), true);
+    assert.equal(find(FOURTH_NAME_ERROR_FIELD).hasClass('hidden'), false);
+  });
+  click(SAVE_BUTTON);
+  andThen(function() {
+    assert.equal(currentURL(), '/multi-starting-empty');
+  });
+  click(REMOVE_LAST_BUTTON);
+  click(SAVE_BUTTON);
+  andThen(function() {
+    assert.equal(currentURL(), '/success');
+  });
+});

--- a/tests/dummy/app/controllers/many-single-property.js
+++ b/tests/dummy/app/controllers/many-single-property.js
@@ -1,0 +1,21 @@
+import Ember from "ember";
+import {ValidationMixin, validateEach} from "ember-cli-simple-validation/mixins/validate";
+
+var ManySinglePropertyController = Ember.Controller.extend(ValidationMixin, {
+    uniqueName: validateEach("name", function (name) {
+        var filtered = this.get("model").filter(function (person) {
+            return person.get("name") === name;
+        });
+        return filtered.length === 1;
+    }),
+    actions: {
+        save: function() {
+            this.set("submitted", true);
+            if(this.get("valid")) {
+                this.transitionToRoute("success");
+            }
+        }
+    }
+});
+
+export default ManySinglePropertyController;

--- a/tests/dummy/app/controllers/multi-starting-empty.js
+++ b/tests/dummy/app/controllers/multi-starting-empty.js
@@ -1,0 +1,28 @@
+import Ember from "ember";
+import Person from 'dummy/models/person';
+import {ValidationMixin, validateEach} from "ember-cli-simple-validation/mixins/validate";
+
+var MultiStartingEmptyController = Ember.ArrayController.extend(ValidationMixin, {
+    uniqueName: validateEach("name", function (name) {
+        var filtered = this.get("model").filter(function (person) {
+            return person.get("name") === name;
+        });
+        return filtered.length === 1;
+    }),
+    actions: {
+        add: function() {
+            this.get("model").pushObject(Person.create());
+        },
+        remove: function(person) {
+            this.get("model").removeObject(person);
+        },
+        save: function() {
+            this.set("submitted", true);
+            if(this.get("valid")) {
+                this.transitionToRoute("success");
+            }
+        }
+    }
+});
+
+export default MultiStartingEmptyController;

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
     this.route("success", {path: "/success"});
     this.route("multi", {path: "/multi"});
     this.route("many", {path: "/many"});
+    this.route("many-single-property", {path: "/many-single-property"});
     this.route("other", {path: "/other"});
     this.route("hash", {path: "/hash"});
     this.route("edits", {path: "/edits"});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,6 +12,7 @@ Router.map(function() {
     this.route("multi", {path: "/multi"});
     this.route("many", {path: "/many"});
     this.route("many-single-property", {path: "/many-single-property"});
+    this.route("multi-starting-empty", {path: "/multi-starting-empty"});
     this.route("other", {path: "/other"});
     this.route("hash", {path: "/hash"});
     this.route("edits", {path: "/edits"});

--- a/tests/dummy/app/routes/many-single-property.js
+++ b/tests/dummy/app/routes/many-single-property.js
@@ -1,0 +1,11 @@
+import Ember from "ember";
+import Many from 'dummy/models/many';
+
+export default Ember.Route.extend({
+    model: function() {
+        var one = Many.create();
+        var two = Many.create();
+        var three = Many.create();
+        return Ember.A([one, two, three]);
+    }
+});

--- a/tests/dummy/app/routes/multi-starting-empty.js
+++ b/tests/dummy/app/routes/multi-starting-empty.js
@@ -1,0 +1,8 @@
+import Ember from "ember";
+import Person from 'dummy/models/person';
+
+export default Ember.Route.extend({
+    model: function() {
+        return Ember.A([]);
+    }
+});

--- a/tests/dummy/app/templates/many-single-property.hbs
+++ b/tests/dummy/app/templates/many-single-property.hbs
@@ -1,0 +1,8 @@
+{{#each model as |person index|}}
+  <div class="name-parent-div">
+    {{input value=person.name placeholder="name"}}
+    {{#validation-error-field array=model submitted=submitted delayed=true className="name-input-error" field="name" model=person index=index validation="uniqueName"}}Name must be unique{{/validation-error-field}}
+  </div>
+{{/each}}
+
+<button class="save" {{action "save"}}>Save</button>

--- a/tests/dummy/app/templates/multi-starting-empty.hbs
+++ b/tests/dummy/app/templates/multi-starting-empty.hbs
@@ -1,0 +1,13 @@
+{{#each model as |person index|}}
+  <div class="name-parent-div">
+    {{input value=person.name placeholder="name"}}
+    {{#validation-error-field array=model submitted=submitted className="red" field="name" model=person index=index validation="uniqueName"}}invalid name{{/validation-error-field}}
+  </div>
+
+  <button class="remove" {{action "remove" person}}>Remove</button>
+{{/each}}
+
+<button class="save" {{action "save"}}>Save</button>
+
+<br />
+<button class="add" {{action "add"}}>Add Another</button>


### PR DESCRIPTION
To solve the issue @benkiefer found in #20 I expanded the `validation-error-field` api such that if the array itself is passed to the component we can fire the visible computed for each model in the array.

@benkiefer can look this over today and provide some feedback? It solves the core problem and I broke the commits up so you could see the absolute minimum required for this change. 

One thing worth discussing in particular is that this is an "opt-in" feature at the moment meaning you aren't required to supply the "array" unless you want each validation to re-compute. At first I assumed this was a bug but as I think about it more it's possible this might be a desirable option. It also seems to play nicely because with this approach we don't need to do a major version /release as it's backwards compatible.
