### PR TITLE
[EMBER]: support the now deprecated targetObject

### DIFF
--- a/addon/components/validation-error-field.js
+++ b/addon/components/validation-error-field.js
@@ -33,7 +33,8 @@ var ValidationErrorField = Ember.Component.extend({
             var submitted = this.get("submitted");
             var className = this.get("className");
             var validator = this.get("validation");
-            var fieldValidation = this.get("targetObject." + validator + index + "Validation");
+            var targetObject = this.get("targetObject") || this.get("_targetObject");
+            var fieldValidation = targetObject.get(validator + index + "Validation");
             var validation = index >= 0 ? fieldValidation : validator;
             var condition = delayed === true ? !validation && submitted : !validation && (isPrimed || submitted);
             if(condition) {


### PR DESCRIPTION
Thanks to @benkiefer it appears that in ember 2.9 the once functional targetObject is no more. This PR keeps ember 1.13.13 users happy/ but includes a workaround for v2.9 users of the library.

I'll publish this as v1.4.1 when the build is green. We need a long term solution for this as the hack `_targetObject` isn't ideal. More on that once I find a solution/api I'm happy with

https://github.com/emberjs/ember.js/issues/14168